### PR TITLE
카테고리 및 테마 탭 전환시 밑 item 나오는 문제

### DIFF
--- a/js/food/food.js
+++ b/js/food/food.js
@@ -9,7 +9,7 @@ const dt1Content = document.querySelector(".dt1_content");
 const dt2Content = document.querySelector(".dt2_content");
 
 const categoryList = document.querySelector(".categoryList");
-const themeList = document.querySelector(".themeList");
+const themeList = document.querySelector(".themeLists");
 
 food_kind_btn.addEventListener("click", () => {
   food_kind_check.classList.toggle("active");


### PR DESCRIPTION
- 푸드 페이지의 테마 탭에서 버튼을 클릭하고 카테고리 탭 클릭 시 카테고리에 테마 아이템이 표시됨

- 테마 div 태그에서 class name을 변경하고, food.js에서 변경을 해주지 않아 문제 발생

food.js
```javascript
const themeList = document.querySelector(".themeLists"); //themeList에서 themeLists로 변경
```